### PR TITLE
un-hardcode pytorch version plus a bug/docs fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ storage/samples/latest
 To run the analysis script on a trajectory execute the following command  
 
 ```
-python scripts/analyze.py {trajectory_path}
+python scripts/analyse_trajs.py {trajectory_path}
 ```
 
-This will automatically fetch the last generated trajectory. otherwise use the --traj argument to specify a path. The available flags and kw args can be seen by running 
+The available flags and kw args can be seen by running 
 
 ```
 python scripts/analyse_trajs.py --help
@@ -149,17 +149,16 @@ which will show the following options
 
 ```
 positional arguments:
-  trajs            Specify the path to the trajectory file containing the trajectories to be analyzed. Default is 'storage/samples/latest'. If the default path is unchanged, ensure
+  trajs            Specify the path to the trajectory file containing the trajectories to be analyzed. Default is 'storage/samples/latest'. If the default path is unchanged, ensure that the sampling
+                   script has been run prior to analysis.
 
-optional arguments:
+options:
   -h, --help       show this help message and exit
-                   that the sampling script has been run prior to analysis.
-  --root ROOT      Set the base directory where input data is located and where analysis outputs will be stored. The default directory is 'storage'. Modify this if your data and
-                   output directories are different.
-  --lag LAG        Define the temporal lag (in steps) between frames in the ITO trajectory. This value will be used to analyse the reference trajs such that time steps match. The
-                   default value is 100.
-  --no_plot_start  Include this flag to prevent marking the starting point of trajectories in the generated plots. By default, the starting point is marked. This should only be
-                   used if the trajectories was generated with --init_from_eq
+  --root ROOT      Set the base directory where input data is located and where analysis outputs will be stored. The default directory is 'storage'. Modify this if your data and output directories are
+                   different.
+  --lag LAG        Define the temporal lag (in steps) between frames in the ITO trajectory. This value will be used to analyse the reference trajs such that time steps match. The default value is 100.
+  --no_plot_start  Include this flag to prevent marking the starting point of trajectories in the generated plots. By default, the starting point is marked. This should only be used if the trajectories
+                   was generated with --init_from_eq
 ```
 
 Running the script will calculate the VAMP2-scores of the trajectories as well as VAMP2-scores of the reference trajectories, calculated with the appropriate lag. 

--- a/makefile
+++ b/makefile
@@ -2,21 +2,21 @@
 
 install-cpu:
 	pip install -e .
-	pip install torch-scatter -f https://data.pyg.org/whl/torch-2.1.0+cpu.html
-	pip install torch-sparse -f https://data.pyg.org/whl/torch-2.1.0+cpu.html
-	pip install torch-cluster -f https://data.pyg.org/whl/torch-2.1.0+cpu.html
+	pip install torch-scatter -f https://data.pyg.org/whl/torch-$(shell pip show torch | grep Version | sed "s/Version: //g")+cpu.html
+	pip install torch-sparse -f https://data.pyg.org/whl/torch-$(shell pip show torch | grep Version | sed "s/Version: //g")+cpu.html
+	pip install torch-cluster -f https://data.pyg.org/whl/torch-$(shell pip show torch | grep Version | sed "s/Version: //g")+cpu.html
 
 
 install-cu118:
 	pip install -e .
-	pip install torch-scatter -f https://data.pyg.org/whl/torch-2.1.0+cu118.html
-	pip install torch-sparse -f https://data.pyg.org/whl/torch-2.1.0+cu118.html
-	pip install torch-cluster -f https://data.pyg.org/whl/torch-2.1.0+cu118.html
+	pip install torch-scatter -f https://data.pyg.org/whl/torch-$(shell pip show torch | grep Version | sed "s/Version: //g")+cu118.html
+	pip install torch-sparse -f https://data.pyg.org/whl/torch-$(shell pip show torch | grep Version | sed "s/Version: //g")+cu118.html
+	pip install torch-cluster -f https://data.pyg.org/whl/torch-$(shell pip show torch | grep Version | sed "s/Version: //g")+cu118.html
 
 
 install-cu121:
 	pip install -e .
-	pip install torch-scatter -f https://data.pyg.org/whl/torch-2.1.0+cu121.html
-	pip install torch-sparse -f https://data.pyg.org/whl/torch-2.1.0+cu121.html
-	pip install torch-cluster -f https://data.pyg.org/whl/torch-2.1.0+cu121.html
+	pip install torch-scatter -f https://data.pyg.org/whl/torch-$(shell pip show torch | grep Version | sed "s/Version: //g")+cu121.html
+	pip install torch-sparse -f https://data.pyg.org/whl/torch-$(shell pip show torch | grep Version | sed "s/Version: //g")+cu121.html
+	pip install torch-cluster -f https://data.pyg.org/whl/torch-$(shell pip show torch | grep Version | sed "s/Version: //g")+cu121.html
 

--- a/scripts/analyse_trajs.py
+++ b/scripts/analyse_trajs.py
@@ -102,7 +102,7 @@ def compute_dihedral_angles(traj, topology):
 
 
 def featurize_trajs(trajs, topology):
-    featurized_trajs = np.stack(featurize_traj(traj, topology) for traj in trajs)
+    featurized_trajs = np.stack([featurize_traj(traj, topology) for traj in trajs])
     nan_mask = np.isnan(featurized_trajs).any(axis=(1, 2))
 
     return featurized_trajs[~nan_mask]


### PR DESCRIPTION
Hello, just submitting this PR to smooth out some issues I ran into when trying to run the code. Now that pytorch 2.2 is out, `pip install -e .` picked that one to install, while the other pip installs were still hardcoded to 2.1.0. This resulted in an Undefined Symbol error. My solution here is just to check what version of pytorch was installed and make the requested versions of the other packages consistent with that.

Also, the analyse script seemed to have a bug where a list comprehension should have been used instead of a generator comprehension.